### PR TITLE
Pass in current process environment

### DIFF
--- a/lib/param_query.js
+++ b/lib/param_query.js
@@ -85,7 +85,8 @@ class ParameterQuery {
         let result = spawnSync( 'node', [ __dirname + '/ssm_sync' ], {
 
             input: str,
-            maxBuffer: 4000000
+            maxBuffer: 4000000,
+            env: process.env
         });
 
         let queryResult = JSON.parse( result.stdout.toString() );


### PR DESCRIPTION
Sometimes we get our AWS credentials from other places than the environment, and sometimes we get them from the environment. Sometimes those are access_key, secret_key and sometimes they are special internal aws credentials (like ECS credentials). We have found it easier to just make sure all aws credentials are in the `process.env` environment before starting any aws service. This allows aws to chose the credentials it wants to use.

This PR will pass the current (potentially modified) environment of the current process into the spawned child sync process rather than just using the external environment that was passed into the parent process.