### PR TITLE
Add alternative output for SSM error

### DIFF
--- a/lib/param_query.js
+++ b/lib/param_query.js
@@ -96,7 +96,7 @@ class ParameterQuery {
         }
         else {
 
-            throw new Error( queryResult.err.message );
+            throw new Error( queryResult.err.message || queryResult.err.code );
         }
     }
 


### PR DESCRIPTION
Under some circumstances `queryResult.err.message` can be `null`, this change offers up the `queryResult.err.code` as an alternative when that is the case.

"ParameterNotFound" example error:
```
{ message: null,
  code: 'ParameterNotFound',
  time: '2018-08-02T12:24:05.007Z',
  requestId: 'e921a76c-b60c-47f4-9265-26fbc0089cd5',
  statusCode: 400,
  retryable: false,
  retryDelay: 29.36114768004634 }
```