### PR TITLE
  closes issue #15,  sets aws-sdk as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   },
   "author": "Vandium Software Inc.",
   "license": "BSD-3-Clause",
-  "dependencies": {},
+  "dependencies": {
+    "aws-sdk": "^2.553.0"
+  },
   "devDependencies": {
-    "aws-sdk": "^2.325.0",
     "chai": "^4.1.2",
     "proxyquire": "^2.1.0",
     "mocha": "^6.1.4",


### PR DESCRIPTION
related:  https://github.com/vandium-io/aws-param-store/issues/15

when consuming this module, and running `npm install --production`  the expected package `aws-sdk` was not present.